### PR TITLE
silencing warning on osx

### DIFF
--- a/include/pbbam/internal/PbiFilter.inl
+++ b/include/pbbam/internal/PbiFilter.inl
@@ -201,6 +201,7 @@ struct PbiFilterPrivate
 
         else
             assert(false); // invalid composite filter type
+        return false;
     }
 
     PbiFilter::CompositionType type_;


### PR DESCRIPTION
clang is still dumb
```
In file included from /opt/pitchfork/workspace/pbbam/include/pbbam/PbiFilter.h:341:
/opt/pitchfork/workspace/pbbam/include/pbbam/internal/PbiFilter.inl:204:5: warning: control may reach end of non-void function [-Wreturn-type]
    }
    ^
1 warning generated.
```