### PR TITLE
Retain order of reads when possible

### DIFF
--- a/include/pbbam/internal/CompositeBamReader.inl
+++ b/include/pbbam/internal/CompositeBamReader.inl
@@ -355,7 +355,7 @@ PbiFilterCompositeBamReader<OrderByType>::Filter(const PbiFilter& filter)
 
 template<typename OrderByType>
 inline void PbiFilterCompositeBamReader<OrderByType>::UpdateSort(void)
-{ std::sort(mergeQueue_.begin(), mergeQueue_.end(), merge_sorter_type{}); }
+{ std::stable_sort(mergeQueue_.begin(), mergeQueue_.end(), merge_sorter_type{}); }
 
 // ------------------------------
 // SequentialCompositeBamReader


### PR DESCRIPTION
Even though we use `Compare::None`, we need `stable_sort<>`, according
to my testing. Not sure why, but with this change the reads are in
order.

See https://bugzilla.nanofluidics.com/show_bug.cgi?id=33406