### PR TITLE
Rely on PATH to find test programs

### DIFF
--- a/tests/src/cram/bam2sam.t
+++ b/tests/src/cram/bam2sam.t
@@ -1,6 +1,8 @@
 Setup:
 
-  $ BAM2SAM="$TESTDIR/../../../bin/bam2sam" && export BAM2SAM
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+
+  $ BAM2SAM="bam2sam" && export BAM2SAM
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
 

--- a/tests/src/cram/pbindexdump_cpp.t
+++ b/tests/src/cram/pbindexdump_cpp.t
@@ -1,6 +1,8 @@
 Setup:
 
-  $ PBINDEXDUMP="$TESTDIR/../../../bin/pbindexdump" && export PBINDEXDUMP
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+
+  $ PBINDEXDUMP="pbindexdump" && export PBINDEXDUMP
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
 

--- a/tests/src/cram/pbindexdump_json.t
+++ b/tests/src/cram/pbindexdump_json.t
@@ -1,6 +1,8 @@
 Setup:
 
-  $ PBINDEXDUMP="$TESTDIR/../../../bin/pbindexdump" && export PBINDEXDUMP
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+
+  $ PBINDEXDUMP="pbindexdump" && export PBINDEXDUMP
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
 

--- a/tests/src/cram/pbmerge_aligned_ordering.t
+++ b/tests/src/cram/pbmerge_aligned_ordering.t
@@ -1,8 +1,8 @@
 Setup:
 
-  $ TOOLS_BIN="$TESTDIR/../../../bin" && export TOOLS_BIN
-  $ PBMERGE="$TOOLS_BIN/pbmerge" && export PBMERGE
-  $ BAM2SAM="$TOOLS_BIN/bam2sam" && export BAM2SAM
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+  $ PBMERGE="pbmerge" && export PBMERGE
+  $ BAM2SAM="bam2sam" && export BAM2SAM
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
   $ INPUT_1="$DATADIR/dataset/bam_mapping_1.bam" && export INPUT_1

--- a/tests/src/cram/pbmerge_dataset.t
+++ b/tests/src/cram/pbmerge_dataset.t
@@ -1,8 +1,8 @@
 Setup:
 
-  $ TOOLS_BIN="$TESTDIR/../../../bin" && export TOOLS_BIN
-  $ PBMERGE="$TOOLS_BIN/pbmerge" && export PBMERGE
-  $ BAM2SAM="$TOOLS_BIN/bam2sam" && export BAM2SAM
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+  $ PBMERGE="pbmerge" && export PBMERGE
+  $ BAM2SAM="bam2sam" && export BAM2SAM
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
   $ INPUT_XML="$DATADIR/polymerase/consolidate.subread.dataset.xml" && export INPUT_XML

--- a/tests/src/cram/pbmerge_fofn.t
+++ b/tests/src/cram/pbmerge_fofn.t
@@ -1,8 +1,8 @@
 Setup:
 
-  $ TOOLS_BIN="$TESTDIR/../../../bin" && export TOOLS_BIN
-  $ PBMERGE="$TOOLS_BIN/pbmerge" && export PBMERGE
-  $ BAM2SAM="$TOOLS_BIN/bam2sam" && export BAM2SAM
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+  $ PBMERGE="pbmerge" && export PBMERGE
+  $ BAM2SAM="bam2sam" && export BAM2SAM
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
   $ INPUT_FOFN="$DATADIR/merge.fofn" && export INPUT_FOFN

--- a/tests/src/cram/pbmerge_mixed_ordering.t
+++ b/tests/src/cram/pbmerge_mixed_ordering.t
@@ -1,8 +1,8 @@
 Setup:
 
-  $ TOOLS_BIN="$TESTDIR/../../../bin" && export TOOLS_BIN
-  $ PBMERGE="$TOOLS_BIN/pbmerge" && export PBMERGE
-  $ BAM2SAM="$TOOLS_BIN/bam2sam" && export BAM2SAM
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+  $ PBMERGE="pbmerge" && export PBMERGE
+  $ BAM2SAM="bam2sam" && export BAM2SAM
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
   $ UNALIGNED_BAM="$DATADIR/polymerase/internal.hqregions.bam" && export UNALIGNED_BAM

--- a/tests/src/cram/pbmerge_pacbio_ordering.t
+++ b/tests/src/cram/pbmerge_pacbio_ordering.t
@@ -1,8 +1,8 @@
 Setup:
 
-  $ TOOLS_BIN="$TESTDIR/../../../bin" && export TOOLS_BIN
-  $ PBMERGE="$TOOLS_BIN/pbmerge" && export PBMERGE
-  $ BAM2SAM="$TOOLS_BIN/bam2sam" && export BAM2SAM
+  $ PATH="$TESTDIR/../../../bin:$PATH" && export PATH
+  $ PBMERGE="pbmerge" && export PBMERGE
+  $ BAM2SAM="bam2sam" && export BAM2SAM
 
   $ DATADIR="$TESTDIR/../../data" && export DATADIR
   $ HQREGION_BAM="$DATADIR/polymerase/internal.hqregions.bam" && export HQREGION_BAM


### PR DESCRIPTION
Add flexibility to the tests so that they can be used if the
executables are installed elsewhere rather than fresh out of
the build tree.
